### PR TITLE
default latency effect enhancements and input tolerance

### DIFF
--- a/src/fault.js
+++ b/src/fault.js
@@ -1,12 +1,23 @@
-const flatLatency = async (experiment) => {
-  if(experiment && experiment.effect && experiment.effect.latency)
+const latency = async (experiment) => {
+  const effect = experiment.effect;
+
+  if(experiment && experiment.effect && effect.latency && effect.latency && typeof effect.latency === "number") {
+    await timeout(experiment.effect.latency);
+  } else if(experiment && experiment.effect && effect.latency && effect.latency && typeof effect.latency === "string") {
     await timeout(parseInt(experiment.effect.latency, 10));
+  } else if(experiment && experiment.effect && effect.latency && effect.latency && typeof effect.latency === "object") {
+    let ms = (effect.latency.ms && typeof effect.latency.ms === "number")? effect.latency.ms : 0;
+    let jitter = (effect.latency.jitter && typeof effect.latency.jitter === "number")? effect.latency.jitter * Math.random() : 0;
+    await timeout(ms + jitter);
+  }
 }
 
 const exception = (experiment) => {
-  if(experiment && experiment.effect && experiment.effect.exception) 
+  const effect = experiment.effect;
+
+  if(experiment && experiment.effect && effect.exception) 
     if(experiment.effect.exception.message)
-      throw new Error(experiment.effect.exception.message);
+      throw new Error(effect.exception.message);
     else
       throw new Error('Exception injected by Gremlin');
 }
@@ -16,8 +27,8 @@ function timeout(ms) {
 }
 
 const delayedException = async (e) => {
-  await flatLatency(e);
+  await latency(e);
   exception(e);
 }
 
-module.exports = exports = { flatLatency, exception, delayedException };
+module.exports = exports = { latency, exception, delayedException };


### PR DESCRIPTION
* adds tolerance for "latency" effect map value to be either a string or number (still specified in milliseconds)
* adds support for "latency" to be an object
* object form has two well-known attributes: ms and jitter
* "latency.ms" is a number and specifies the minimum latency in milliseconds
* "latency.jitter" is a number and specifies the maximum amount of additional random latency in milliseconds