### PR TITLE
Require FFE to be 1 or true

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ module.exports.handler = async (event) => {
 
 ## Enabling the SDK in your Environment
 
-*Don't forget to enable the SDK by setting the FAILURE_FLAGS_ENABLED environment variable!* If this environment variable is not set then the SDK will short-circuit and no attempt to fetch experiments will be made.
+*Don't forget to enable the SDK by setting the FAILURE_FLAGS_ENABLED environment variable!* If this environment variable is not set then the SDK will short-circuit and no attempt to fetch experiments will be made. The variable must be set to either `true` or `1`.
 
 ## Extensibility
 

--- a/index.test.js
+++ b/index.test.js
@@ -259,8 +259,32 @@ test('invokeFailureFlag does call callback', async () => {
   expect(setTimeout).toHaveBeenCalledTimes(0);
 });
 
-test('invokeFailureFlag does nothing if FAILURE_FLAGS_ENABLED is not truthy', async () => {
+test('invokeFailureFlag does nothing if FAILURE_FLAGS_ENABLED is not set', async () => {
   delete process.env.FAILURE_FLAGS_ENABLED
+  expect(await failureflags.invokeFailureFlag({
+    name: 'custom',
+    labels: {a:'1',b:'2'}})).toBe(false);
+  expect(setTimeout).toHaveBeenCalledTimes(0);
+});
+
+test('invokeFailureFlag does nothing if FAILURE_FLAGS_ENABLED is "0"', async () => {
+  process.env.FAILURE_FLAGS_ENABLED = "0"
+  expect(await failureflags.invokeFailureFlag({
+    name: 'custom',
+    labels: {a:'1',b:'2'}})).toBe(false);
+  expect(setTimeout).toHaveBeenCalledTimes(0);
+});
+
+test('invokeFailureFlag does nothing if FAILURE_FLAGS_ENABLED is "hello"', async () => {
+  process.env.FAILURE_FLAGS_ENABLED = "hello"
+  expect(await failureflags.invokeFailureFlag({
+    name: 'custom',
+    labels: {a:'1',b:'2'}})).toBe(false);
+  expect(setTimeout).toHaveBeenCalledTimes(0);
+});
+
+test('invokeFailureFlag does nothing if FAILURE_FLAGS_ENABLED is ""', async () => {
+  process.env.FAILURE_FLAGS_ENABLED = ""
   expect(await failureflags.invokeFailureFlag({
     name: 'custom',
     labels: {a:'1',b:'2'}})).toBe(false);

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -22,7 +22,7 @@ const fetchExperiment = async (name, labels = {}, debug = false) => {
   if(debug) console.log('fetch experiment for', name, labels);
 
   return new Promise((resolve, reject) => {
-    if(!process.env.FAILURE_FLAGS_ENABLED) {
+    if(!process.env.FAILURE_FLAGS_ENABLED || !(process.env.FAILURE_FLAGS_ENABLED === "true" || process.env.FAILURE_FLAGS_ENABLED === "1")) {
       reject(new Error('failure flags is not enabled'));
       return
     }


### PR DESCRIPTION
This change requires that FAILURE_FLAGS_ENABLED is set to either `true` or `1`. If the variable is unset or contains any other value then the library will fail safe.